### PR TITLE
Fix crash for GUI calculation

### DIFF
--- a/src/main/java/com/norwood/mcheli/hud/MCH_HudItemLine.java
+++ b/src/main/java/com/norwood/mcheli/hud/MCH_HudItemLine.java
@@ -12,7 +12,7 @@ public class MCH_HudItemLine extends MCH_HudItem {
         this.pos = new String[position.length];
 
         for (int i = 0; i < position.length; i++) {
-            this.pos[i] = position[i].toLowerCase();
+            this.pos[i] = toFormula(position[i]);
         }
     }
 


### PR DESCRIPTION
MCH_HudItemLine didn't call toFormula() on position values, so entries like +50 from tv_missile.txt crashed Aviator.

One-line fix: `position[i].toLowerCase()` changed to `toFormula(position[i]),` matching all other HUD items.