### PR TITLE
Fix Neonium entity culling freeze by using INFINITE_EXTENT_AABB

### DIFF
--- a/src/main/java/com/norwood/mcheli/wrapper/W_Entity.java
+++ b/src/main/java/com/norwood/mcheli/wrapper/W_Entity.java
@@ -136,9 +136,6 @@ public abstract class W_Entity extends Entity {
     @Override
     @SideOnly(Side.CLIENT)
     public AxisAlignedBB getRenderBoundingBox() {
-        double huge = 1.0e6;
-        return new AxisAlignedBB(
-                posX - huge, posY - huge, posZ - huge,
-                posX + huge, posY + huge, posZ + huge);
+        return net.minecraft.tileentity.TileEntity.INFINITE_EXTENT_AABB;
     }
 }


### PR DESCRIPTION
The previous bounding box caused Neonium to try and iterate over millions of chunks to check visibility, instantly freezing the game. 