### PR TITLE
Fix camera and dummy entity state leaking into non-MCHeli rideables

### DIFF
--- a/src/main/java/com/norwood/mcheli/MCH_ViewEntityDummy.java
+++ b/src/main/java/com/norwood/mcheli/MCH_ViewEntityDummy.java
@@ -29,7 +29,6 @@ public class MCH_ViewEntityDummy extends EntityPlayerSP {
             instance = new MCH_ViewEntityDummy(w);
             instance.movementInput = new MovementInput();
             instance.setPosition(0.0, -4.0, 0.0);
-            w.spawnEntity(instance);
         }
         return instance;
     }

--- a/src/main/java/com/norwood/mcheli/event/ClientCommonTickHandler.java
+++ b/src/main/java/com/norwood/mcheli/event/ClientCommonTickHandler.java
@@ -426,14 +426,16 @@ public class ClientCommonTickHandler extends W_TickHandler {
     }
 
     private void updateViewEntityDummy(MCH_EntityAircraft ac, EntityPlayer player) {
-        Entity de = MCH_ViewEntityDummy.getInstance(player.world);
-        if (de != null) {
-            de.rotationYaw = player.rotationYaw;
-            de.prevRotationYaw = player.prevRotationYaw;
-            if (ac != null) {
-                MCH_WeaponSet wi = ac.getCurrentWeapon(player);
-                if (wi != null && wi.getInfo() != null && wi.getInfo().fixCameraPitch) {
-                    de.rotationPitch = de.prevRotationPitch = 0.0F;
+        if (ac != null || player.getRidingEntity() instanceof MCH_EntityGLTD || player.getRidingEntity() instanceof IUavStation) {
+            Entity de = MCH_ViewEntityDummy.getInstance(player.world);
+            if (de != null) {
+                de.rotationYaw = player.rotationYaw;
+                de.prevRotationYaw = player.prevRotationYaw;
+                if (ac != null) {
+                    MCH_WeaponSet wi = ac.getCurrentWeapon(player);
+                    if (wi != null && wi.getInfo() != null && wi.getInfo().fixCameraPitch) {
+                        de.rotationPitch = de.prevRotationPitch = 0.0F;
+                    }
                 }
             }
         }
@@ -469,12 +471,14 @@ public class ClientCommonTickHandler extends W_TickHandler {
     public void onRenderTickPost(float partialTicks) {
         if (this.mc.player != null) {
             MCH_ClientTickHandlerBase.applyRotLimit(this.mc.player);
-            Entity e = MCH_ViewEntityDummy.getInstance(this.mc.player.world);
-            if (e != null) {
-                e.rotationPitch = this.mc.player.rotationPitch;
-                e.rotationYaw = this.mc.player.rotationYaw;
-                e.prevRotationPitch = this.mc.player.prevRotationPitch;
-                e.prevRotationYaw = this.mc.player.prevRotationYaw;
+            if (ridingAircraft != null) {
+                Entity e = MCH_ViewEntityDummy.getInstance(this.mc.player.world);
+                if (e != null) {
+                    e.rotationPitch = this.mc.player.rotationPitch;
+                    e.rotationYaw = this.mc.player.rotationYaw;
+                    e.prevRotationPitch = this.mc.player.prevRotationPitch;
+                    e.prevRotationYaw = this.mc.player.prevRotationYaw;
+                }
             }
         }
         guiTickHandler.handleGui(partialTicks);

--- a/src/main/java/com/norwood/mcheli/event/MCH_ClientTickHandlerBase.java
+++ b/src/main/java/com/norwood/mcheli/event/MCH_ClientTickHandlerBase.java
@@ -40,12 +40,12 @@ public abstract class MCH_ClientTickHandlerBase {
         playerRotMaxYaw = max;
         playerRotLimitYaw = true;
         if (e != null) {
-            if (e.rotationPitch < playerRotMinPitch) {
-                e.rotationPitch = playerRotMinPitch;
-                e.prevRotationPitch = playerRotMinPitch;
-            } else if (e.rotationPitch > playerRotMaxPitch) {
-                e.rotationPitch = playerRotMaxPitch;
-                e.prevRotationPitch = playerRotMaxPitch;
+            if (e.rotationYaw < playerRotMinYaw) {
+                e.rotationYaw = playerRotMinYaw;
+                e.prevRotationYaw = playerRotMinYaw;
+            } else if (e.rotationYaw > playerRotMaxYaw) {
+                e.rotationYaw = playerRotMaxYaw;
+                e.prevRotationYaw = playerRotMaxYaw;
             }
         }
     }
@@ -53,7 +53,7 @@ public abstract class MCH_ClientTickHandlerBase {
     public static void initRotLimit() {
         playerRotMinPitch = -90.0F;
         playerRotMaxPitch = 90.0F;
-        playerRotLimitYaw = false;
+        playerRotLimitPitch = false;
         playerRotMinYaw = -180.0F;
         playerRotMaxYaw = 180.0F;
         playerRotLimitYaw = false;
@@ -71,7 +71,15 @@ public abstract class MCH_ClientTickHandlerBase {
                 }
             }
 
-            if (!playerRotLimitYaw) {}
+            if (playerRotLimitYaw) {
+                if (e.rotationYaw < playerRotMinYaw) {
+                    e.rotationYaw = playerRotMinYaw;
+                    e.prevRotationYaw = playerRotMinYaw;
+                } else if (e.rotationYaw > playerRotMaxYaw) {
+                    e.rotationYaw = playerRotMaxYaw;
+                    e.prevRotationYaw = playerRotMaxYaw;
+                }
+            }
         }
     }
 

--- a/src/main/java/com/norwood/mcheli/helper/client/MCH_CameraManager.java
+++ b/src/main/java/com/norwood/mcheli/helper/client/MCH_CameraManager.java
@@ -60,7 +60,7 @@ public class MCH_CameraManager {
     @SubscribeEvent
     static void onCameraSetupEvent(CameraSetup event) {
         float f = event.getEntity().getEyeHeight();
-        if (mc.gameSettings.thirdPersonView > 0) {
+        if (ridingAircraft != null && mc.gameSettings.thirdPersonView > 0) {
             if (mc.gameSettings.thirdPersonView == 2) {
                 GlStateManager.rotate(180.0F, 0.0F, 1.0F, 0.0F);
             }
@@ -88,9 +88,15 @@ public class MCH_CameraManager {
 
     @SubscribeEvent
     static void onFOVModifierEvent(FOVModifier event) {
-        MCH_ViewEntityDummy viewer = MCH_ViewEntityDummy.getInstance(mc.world);
-        if (viewer == event.getEntity() || MCH_ItemRangeFinder.isUsingScope(mc.player)) {
+        if (MCH_ItemRangeFinder.isUsingScope(mc.player)) {
             event.setFOV(event.getFOV() * (1.0F / cameraZoom));
+            return;
+        }
+        if (ridingAircraft != null) {
+            MCH_ViewEntityDummy viewer = MCH_ViewEntityDummy.getInstance(mc.world);
+            if (viewer == event.getEntity()) {
+                event.setFOV(event.getFOV() * (1.0F / cameraZoom));
+            }
         }
     }
 
@@ -113,6 +119,11 @@ public class MCH_CameraManager {
     }
 
     public static void setRidingAircraft(@Nullable MCH_EntityAircraft aircraft) {
+        if (aircraft == null && ridingAircraft != null) {
+            cameraDistance = DEF_THIRD_CAMERA_DIST;
+            cameraZoom = 1.0F;
+            cameraRoll = 0.0F;
+        }
         ridingAircraft = aircraft;
     }
 


### PR DESCRIPTION
- Stop ViewEntityDummy from spawning into the world
- Guard camera/FOV/dummy sync to only run in MCHeli vehicles
- Reset camera state on dismount
- Fix Yaw rotation limit
