### PR TITLE
Fix slow turning regression by scaling rotation constants to deltaSeconds

### DIFF
--- a/src/main/java/com/norwood/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/com/norwood/mcheli/helicopter/MCH_EntityHeli.java
@@ -407,29 +407,29 @@ public class MCH_EntityHeli extends MCH_EntityAircraft {
     }
 
     @Override
-    public void onUpdateAngles(float partialTicks) {
+    public void onUpdateAngles(float deltaSeconds) {
         if (!this.isDestroyed()) {
             float rotRoll = !this.isHovering() ? 0.04F : 0.07F;
-            rotRoll = 1.0F - rotRoll * partialTicks;
+            rotRoll = 1.0F - rotRoll * deltaSeconds;
             if (MCH_ServerSettings.enableRotationLimit) {
                 if (this.getPitch() > MCH_ServerSettings.pitchLimitMax) {
                     this.setRotPitch(this.getPitch() -
-                            Math.abs((this.getPitch() - MCH_ServerSettings.pitchLimitMax) * 0.1F * partialTicks));
+                            Math.abs((this.getPitch() - MCH_ServerSettings.pitchLimitMax) * 0.1F * deltaSeconds));
                 }
 
                 if (this.getPitch() < MCH_ServerSettings.pitchLimitMin) {
                     this.setRotPitch(this.getPitch() +
-                            Math.abs((this.getPitch() - MCH_ServerSettings.pitchLimitMin) * 0.2F * partialTicks));
+                            Math.abs((this.getPitch() - MCH_ServerSettings.pitchLimitMin) * 0.2F * deltaSeconds));
                 }
 
                 if (this.getRoll() > MCH_ServerSettings.rollLimit) {
                     this.setRotRoll(this.getRoll() -
-                            Math.abs((this.getRoll() - MCH_ServerSettings.rollLimit) * 0.03F * partialTicks));
+                            Math.abs((this.getRoll() - MCH_ServerSettings.rollLimit) * 0.03F * deltaSeconds));
                 }
 
                 if (this.getRoll() < -MCH_ServerSettings.rollLimit) {
                     this.setRotRoll(this.getRoll() +
-                            Math.abs((this.getRoll() + MCH_ServerSettings.rollLimit) * 0.03F * partialTicks));
+                            Math.abs((this.getRoll() + MCH_ServerSettings.rollLimit) * 0.03F * deltaSeconds));
                 }
             }
 
@@ -443,11 +443,11 @@ public class MCH_EntityHeli extends MCH_EntityAircraft {
 
             if (MCH_Lib.getBlockIdY(this, 3, -3) == 0) {
                 if (this.moveLeft && !this.moveRight) {
-                    this.setRotRoll(this.getRoll() - 1.2F * partialTicks);
+                    this.setRotRoll(this.getRoll() - 24.0F * deltaSeconds);
                 }
 
                 if (this.moveRight && !this.moveLeft) {
-                    this.setRotRoll(this.getRoll() + 1.2F * partialTicks);
+                    this.setRotRoll(this.getRoll() + 24.0F * deltaSeconds);
                 }
             } else {
                 if (MathHelper.abs(this.getPitch()) < 40.0F) {
@@ -457,11 +457,11 @@ public class MCH_EntityHeli extends MCH_EntityAircraft {
                 if (this.heliInfo.isEnableFoldBlade && this.rotors.length > 0 && this.getFoldBladeStat() == 0 &&
                         !this.isDestroyed()) {
                     if (this.moveLeft && !this.moveRight) {
-                        this.setRotYaw(this.getYaw() - 0.5F * partialTicks);
+                        this.setRotYaw(this.getYaw() - 10.0F * deltaSeconds);
                     }
 
                     if (this.moveRight && !this.moveLeft) {
-                        this.setRotYaw(this.getYaw() + 0.5F * partialTicks);
+                        this.setRotYaw(this.getYaw() + 10.0F * deltaSeconds);
                     }
                 }
             }

--- a/src/main/java/com/norwood/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/com/norwood/mcheli/helicopter/MCH_EntityHeli.java
@@ -410,26 +410,26 @@ public class MCH_EntityHeli extends MCH_EntityAircraft {
     public void onUpdateAngles(float deltaSeconds) {
         if (!this.isDestroyed()) {
             float rotRoll = !this.isHovering() ? 0.04F : 0.07F;
-            rotRoll = 1.0F - rotRoll * deltaSeconds;
+            rotRoll = (float) Math.pow(1.0F - rotRoll, deltaSeconds * 20.0F);
             if (MCH_ServerSettings.enableRotationLimit) {
                 if (this.getPitch() > MCH_ServerSettings.pitchLimitMax) {
                     this.setRotPitch(this.getPitch() -
-                            Math.abs((this.getPitch() - MCH_ServerSettings.pitchLimitMax) * 0.1F * deltaSeconds));
+                            Math.abs((this.getPitch() - MCH_ServerSettings.pitchLimitMax) * 2.0F * deltaSeconds));
                 }
 
                 if (this.getPitch() < MCH_ServerSettings.pitchLimitMin) {
                     this.setRotPitch(this.getPitch() +
-                            Math.abs((this.getPitch() - MCH_ServerSettings.pitchLimitMin) * 0.2F * deltaSeconds));
+                            Math.abs((this.getPitch() - MCH_ServerSettings.pitchLimitMin) * 4.0F * deltaSeconds));
                 }
 
                 if (this.getRoll() > MCH_ServerSettings.rollLimit) {
                     this.setRotRoll(this.getRoll() -
-                            Math.abs((this.getRoll() - MCH_ServerSettings.rollLimit) * 0.03F * deltaSeconds));
+                            Math.abs((this.getRoll() - MCH_ServerSettings.rollLimit) * 0.6F * deltaSeconds));
                 }
 
                 if (this.getRoll() < -MCH_ServerSettings.rollLimit) {
                     this.setRotRoll(this.getRoll() +
-                            Math.abs((this.getRoll() + MCH_ServerSettings.rollLimit) * 0.03F * deltaSeconds));
+                            Math.abs((this.getRoll() + MCH_ServerSettings.rollLimit) * 0.6F * deltaSeconds));
                 }
             }
 

--- a/src/main/java/com/norwood/mcheli/plane/MCH_EntityPlane.java
+++ b/src/main/java/com/norwood/mcheli/plane/MCH_EntityPlane.java
@@ -309,7 +309,7 @@ public class MCH_EntityPlane extends MCH_EntityAircraft {
     }
 
     @Override
-    public void onUpdateAngles(float partialTicks) {
+    public void onUpdateAngles(float deltaSeconds) {
         if (!this.isDestroyed()) {
             if (this.isGunnerMode) {
                 this.setRotPitch(this.getPitch() * 0.95F);
@@ -334,26 +334,26 @@ public class MCH_EntityPlane extends MCH_EntityAircraft {
                 }
 
                 if (this.moveLeft && !this.moveRight) {
-                    this.setRotYaw(this.getYaw() - 0.6F * gmy * partialTicks);
+                    this.setRotYaw(this.getYaw() - 12.0F * gmy * deltaSeconds);
                 }
 
                 if (this.moveRight && !this.moveLeft) {
-                    this.setRotYaw(this.getYaw() + 0.6F * gmy * partialTicks);
+                    this.setRotYaw(this.getYaw() + 12.0F * gmy * deltaSeconds);
                 }
             } else if (!MCH_Config.MouseControlFlightSimMode.prmBool) {
-                this.rotationByKey(partialTicks);
+                this.rotationByKey(deltaSeconds);
                 this.setRotRoll(this.getRoll() + this.addkeyRotValue * 0.5F * this.getAcInfo().mobilityRoll);
             }
 
-            this.addkeyRotValue = (float) (this.addkeyRotValue * (1.0 - 0.1F * partialTicks));
+            this.addkeyRotValue = (float) (this.addkeyRotValue * (1.0 - 0.1F * deltaSeconds));
             if (!isFly && MathHelper.abs(this.getPitch()) < 40.0F) {
                 this.applyOnGroundPitch(0.97F);
             }
 
             if (this.getNozzleRotation() > 0.001F) {
-                float rot = 1.0F - 0.03F * partialTicks;
+                float rot = 1.0F - 0.03F * deltaSeconds;
                 this.setRotPitch(this.getPitch() * rot);
-                rot = 1.0F - 0.1F * partialTicks;
+                rot = 1.0F - 0.1F * deltaSeconds;
                 this.setRotRoll(this.getRoll() * rot);
             }
         }

--- a/src/main/java/com/norwood/mcheli/plane/MCH_EntityPlane.java
+++ b/src/main/java/com/norwood/mcheli/plane/MCH_EntityPlane.java
@@ -290,8 +290,8 @@ public class MCH_EntityPlane extends MCH_EntityAircraft {
         }
     }
 
-    private void rotationByKey(float partialTicks) {
-        float rot = 0.2F;
+    private void rotationByKey(float deltaSeconds) {
+        float rot = 4.0F;
         if (!MCH_Config.MouseControlFlightSimMode.prmBool && this.getVtolMode() != 0) {
             rot *= 0.0F;
         }
@@ -299,11 +299,11 @@ public class MCH_EntityPlane extends MCH_EntityAircraft {
         if (!this.addKeyFlag) {
             this.addKeyFlag = true;
             if (this.moveLeft && !this.moveRight) {
-                this.addkeyRotValue -= rot * partialTicks;
+                this.addkeyRotValue -= rot * deltaSeconds;
             }
 
             if (this.moveRight && !this.moveLeft) {
-                this.addkeyRotValue += rot * partialTicks;
+                this.addkeyRotValue += rot * deltaSeconds;
             }
         }
     }
@@ -312,10 +312,10 @@ public class MCH_EntityPlane extends MCH_EntityAircraft {
     public void onUpdateAngles(float deltaSeconds) {
         if (!this.isDestroyed()) {
             if (this.isGunnerMode) {
-                this.setRotPitch(this.getPitch() * 0.95F);
-                this.setRotYaw(this.getYaw() + this.getAcInfo().autoPilotRot * 0.2F);
+                this.setRotPitch(this.getPitch() * (float) Math.pow(0.95, deltaSeconds * 20.0F));
+                this.setRotYaw(this.getYaw() + this.getAcInfo().autoPilotRot * 4.0F * deltaSeconds);
                 if (MathHelper.abs(this.getRoll()) > 20.0F) {
-                    this.setRotRoll(this.getRoll() * 0.95F);
+                    this.setRotRoll(this.getRoll() * (float) Math.pow(0.95, deltaSeconds * 20.0F));
                 }
             }
 
@@ -345,15 +345,15 @@ public class MCH_EntityPlane extends MCH_EntityAircraft {
                 this.setRotRoll(this.getRoll() + this.addkeyRotValue * 0.5F * this.getAcInfo().mobilityRoll);
             }
 
-            this.addkeyRotValue = (float) (this.addkeyRotValue * (1.0 - 0.1F * deltaSeconds));
+            this.addkeyRotValue = (float) (this.addkeyRotValue * Math.pow(0.9, deltaSeconds * 20.0F));
             if (!isFly && MathHelper.abs(this.getPitch()) < 40.0F) {
                 this.applyOnGroundPitch(0.97F);
             }
 
             if (this.getNozzleRotation() > 0.001F) {
-                float rot = 1.0F - 0.03F * deltaSeconds;
+                float rot = (float) Math.pow(0.97, deltaSeconds * 20.0F);
                 this.setRotPitch(this.getPitch() * rot);
-                rot = 1.0F - 0.1F * deltaSeconds;
+                rot = (float) Math.pow(0.9, deltaSeconds * 20.0F);
                 this.setRotRoll(this.getRoll() * rot);
             }
         }

--- a/src/main/java/com/norwood/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/com/norwood/mcheli/ship/MCH_EntityShip.java
@@ -292,8 +292,8 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
         }
     }
 
-    private void rotationByKey(float partialTicks) {
-        float rot = 0.2F;
+    private void rotationByKey(float deltaSeconds) {
+        float rot = 4.0F;
         if (!MCH_Config.MouseControlFlightSimMode.prmBool && this.getVtolMode() != 0) {
             rot *= 0.0F;
         }
@@ -301,11 +301,11 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
         if (!this.addKeyFlag) {
             this.addKeyFlag = true;
             if (this.moveLeft && !this.moveRight) {
-                this.addkeyRotValue -= rot * partialTicks;
+                this.addkeyRotValue -= rot * deltaSeconds;
             }
 
             if (this.moveRight && !this.moveLeft) {
-                this.addkeyRotValue += rot * partialTicks;
+                this.addkeyRotValue += rot * deltaSeconds;
             }
         }
     }
@@ -314,10 +314,10 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
     public void onUpdateAngles(float deltaSeconds) {
         if (!this.isDestroyed()) {
             if (this.isGunnerMode) {
-                this.setRotPitch(this.getPitch() * 0.95F);
-                this.setRotYaw(this.getYaw() + this.getAcInfo().autoPilotRot * 0.2F);
+                this.setRotPitch(this.getPitch() * (float) Math.pow(0.95, deltaSeconds * 20.0F));
+                this.setRotYaw(this.getYaw() + this.getAcInfo().autoPilotRot * 4.0F * deltaSeconds);
                 if (MathHelper.abs(this.getRoll()) > 20.0F) {
-                    this.setRotRoll(this.getRoll() * 0.95F);
+                    this.setRotRoll(this.getRoll() * (float) Math.pow(0.95, deltaSeconds * 20.0F));
                 }
             }
 
@@ -347,15 +347,15 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
                 this.setRotRoll(this.getRoll() + this.addkeyRotValue * 0.5F * this.getAcInfo().mobilityRoll);
             }
 
-            this.addkeyRotValue = (float) (this.addkeyRotValue * (1.0 - 0.1F * deltaSeconds));
+            this.addkeyRotValue = (float) (this.addkeyRotValue * Math.pow(0.9, deltaSeconds * 20.0F));
             if (!isFly && MathHelper.abs(this.getPitch()) < 40.0F) {
                 this.applyOnGroundPitch(0.97F);
             }
 
             if (this.getNozzleRotation() > 0.001F) {
-                float rot = 1.0F - 0.03F * deltaSeconds;
+                float rot = (float) Math.pow(0.97, deltaSeconds * 20.0F);
                 this.setRotPitch(this.getPitch() * rot);
-                rot = 1.0F - 0.1F * deltaSeconds;
+                rot = (float) Math.pow(0.9, deltaSeconds * 20.0F);
                 this.setRotRoll(this.getRoll() * rot);
             }
         }

--- a/src/main/java/com/norwood/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/com/norwood/mcheli/ship/MCH_EntityShip.java
@@ -311,7 +311,7 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
     }
 
     @Override
-    public void onUpdateAngles(float partialTicks) {
+    public void onUpdateAngles(float deltaSeconds) {
         if (!this.isDestroyed()) {
             if (this.isGunnerMode) {
                 this.setRotPitch(this.getPitch() * 0.95F);
@@ -336,26 +336,26 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
                 }
 
                 if (this.moveLeft && !this.moveRight) {
-                    this.setRotYaw(this.getYaw() - 0.6F * gmy * partialTicks);
+                    this.setRotYaw(this.getYaw() - 12.0F * gmy * deltaSeconds);
                 }
 
                 if (this.moveRight && !this.moveLeft) {
-                    this.setRotYaw(this.getYaw() + 0.6F * gmy * partialTicks);
+                    this.setRotYaw(this.getYaw() + 12.0F * gmy * deltaSeconds);
                 }
             } else if (!MCH_Config.MouseControlFlightSimMode.prmBool) {
-                this.rotationByKey(partialTicks);
+                this.rotationByKey(deltaSeconds);
                 this.setRotRoll(this.getRoll() + this.addkeyRotValue * 0.5F * this.getAcInfo().mobilityRoll);
             }
 
-            this.addkeyRotValue = (float) (this.addkeyRotValue * (1.0 - 0.1F * partialTicks));
+            this.addkeyRotValue = (float) (this.addkeyRotValue * (1.0 - 0.1F * deltaSeconds));
             if (!isFly && MathHelper.abs(this.getPitch()) < 40.0F) {
                 this.applyOnGroundPitch(0.97F);
             }
 
             if (this.getNozzleRotation() > 0.001F) {
-                float rot = 1.0F - 0.03F * partialTicks;
+                float rot = 1.0F - 0.03F * deltaSeconds;
                 this.setRotPitch(this.getPitch() * rot);
-                rot = 1.0F - 0.1F * partialTicks;
+                rot = 1.0F - 0.1F * deltaSeconds;
                 this.setRotRoll(this.getRoll() * rot);
             }
         }


### PR DESCRIPTION
Fixes #49 (Ships turning way too slowly).
- Fixed incorrect scaling on Ship rotation
- Fixed incorrect scaling on Plane taxiing (ground rotation)
- Fixed incorrect scaling on Helicopter roll and folded-blade turning
- Renamed the parameter from `partialTicks` to `deltaSeconds` mostly just to clear up the confusion that caused this in the first place